### PR TITLE
Fixfork sas csns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 
 #Standard build, need NCrystal as dependency:
 
-find_package(NCrystal 2.4.81 REQUIRED)
+find_package(NCrystal 3.0.0 REQUIRED)
 
 if ( NCPLUGIN_DEVMODE )
   #Compile with very strict C++11 options during normal development (this gives

--- a/include/NCPluginFactory.hh
+++ b/include/NCPluginFactory.hh
@@ -13,8 +13,8 @@ namespace NCPluginNamespace {
   class PluginFactory final : public NC::FactImpl::ScatterFactory {
   public:
     const char * name() const noexcept override;
-    NC::Priority query( const NC::MatCfg& ) const override;
-    NC::ProcImpl::ProcPtr produce( const NC::MatCfg& ) const override;
+    NC::Priority query( const NC::FactImpl::ScatterRequest& ) const override;
+    NC::ProcImpl::ProcPtr produce( const NC::FactImpl::ScatterRequest& ) const override;
   };
 }
 

--- a/include/NCSansModelPicker.hh
+++ b/include/NCSansModelPicker.hh
@@ -23,7 +23,7 @@ namespace NCPluginNamespace {
     //objects (the createFromInfo function will raise BadInput exceptions in
     //case of syntax errors in the @CUSTOM_ section data):
     static bool isApplicable( const NC::Info& );
-    static SansIsotropic createFromInfo( NCrystal::shared_obj<const NCrystal::Info> info ); //will raise BadInput in case of syntax errors
+    static SansIsotropic createFromInfo( const NC::Info& info ); //will raise BadInput in case of syntax errors
 
   private:
     SansModelPicker(const NC::Info& info);

--- a/src/NCPluginFactory.cc
+++ b/src/NCPluginFactory.cc
@@ -40,22 +40,15 @@ const char * NCP::PluginFactory::name() const noexcept
 
 NC::Priority NCP::PluginFactory::query( const NC::MatCfg& cfg ) const
 {
-  if ( ! SansModelPicker::isApplicable(*globalCreateInfo(cfg)) )
+  if ( ! ( cfg.get_sans() && SansModelPicker::isApplicable(cfg.info()) ) )
     return NC::Priority::Unable;
   return NC::Priority{999};
 }
 
-NC::ProcImpl::ProcPtr NCP::PluginFactory::produce( const NC::MatCfg& cfg ) const
+NC::ProcImpl::ProcPtr NCP::PluginFactory::produce( const NC::FactImpl::ScatterRequest& cfg ) const
 {
-  // cfg.get_packfact()
-  auto sc_ourmodel = NC::makeSO<PluginScatter>(SansModelPicker::createFromInfo(globalCreateInfo(cfg) ));
-  return sc_ourmodel;
-
-  //fixme: to be enabled again
-  // auto cfg2 = cfg.clone();
-  // auto sc_std = globalCreateScatter(cfg2);
-  //[Comment from TK: No need to clone cfg as cfg2 if you are not going to change any parameters.]
-  //
-  // // Combine and return:
-  // return combineProcs( sc_std, sc_ourmodel );
+  auto sc_ourmodel = NC::makeSO<PluginScatter>( SansModelPicker::createFromInfo(cfg.info()) );
+  auto sc_std = globalCreateScatter( cfg )
+  //NOTE from TK: To get ONLY the sans component when plotting etc., you can simply put "bla.ncmat;comp=sans".
+  return combineProcs( sc_std, sc_ourmodel );
 }

--- a/src/NCPluginFactory.cc
+++ b/src/NCPluginFactory.cc
@@ -38,7 +38,7 @@ const char * NCP::PluginFactory::name() const noexcept
   return NCPLUGIN_NAME_CSTR "Factory";
 }
 
-NC::Priority NCP::PluginFactory::query( const NC::MatCfg& cfg ) const
+NC::Priority NCP::PluginFactory::query( const NC::FactImpl::ScatterRequest& cfg ) const
 {
   if ( ! ( cfg.get_sans() && SansModelPicker::isApplicable(cfg.info()) ) )
     return NC::Priority::Unable;
@@ -48,7 +48,7 @@ NC::Priority NCP::PluginFactory::query( const NC::MatCfg& cfg ) const
 NC::ProcImpl::ProcPtr NCP::PluginFactory::produce( const NC::FactImpl::ScatterRequest& cfg ) const
 {
   auto sc_ourmodel = NC::makeSO<PluginScatter>( SansModelPicker::createFromInfo(cfg.info()) );
-  auto sc_std = globalCreateScatter( cfg )
+  auto sc_std = globalCreateScatter( cfg );
   //NOTE from TK: To get ONLY the sans component when plotting etc., you can simply put "bla.ncmat;comp=sans".
   return combineProcs( sc_std, sc_ourmodel );
 }

--- a/src/NCSansModelPicker.cc
+++ b/src/NCSansModelPicker.cc
@@ -11,7 +11,7 @@ bool NCP::SansModelPicker::isApplicable( const NC::Info& info )
   return info.countCustomSections(pluginNameUpperCase()) > 0;
 }
 
-NCP::SansIsotropic NCP::SansModelPicker::createFromInfo( NCrystal::shared_obj<const NCrystal::Info> info)
+NCP::SansIsotropic NCP::SansModelPicker::createFromInfo( const NC::Info& info)
 {
   auto iq = SansModelPicker(info);
   return SansIsotropic(iq.getQ(), iq.getI());

--- a/testcode/CMakeLists.txt
+++ b/testcode/CMakeLists.txt
@@ -8,7 +8,7 @@ project(NCPluginTestCode_${NCPlugin_NAME} LANGUAGES CXX)
 
 option(NCPLUGIN_INSTALLSYMLINKS "Use symlinks when installing non-binary files (thus developers can avoid a build+install step when editing scripts and data files)" OFF)
 
-find_package(NCrystal 2.4.0 REQUIRED)
+find_package(NCrystal 3.0.0 REQUIRED)
 
 function(install_maybe_as_symlink installtype file)
   #Apparently cmake will install as symlinks if we first create the symlinks in

--- a/testcode/utils/bootstrap.sh
+++ b/testcode/utils/bootstrap.sh
@@ -80,7 +80,7 @@ Usage:
 
   ncpluginbuild (--clear|-c) : clean bld output, environment variables and even
                                delete the ncpluginbuild command. (you must
-                               ". testcode/util/bootstrap.sh" to get it back
+                               ". testcode/utils/bootstrap.sh" to get it back
                                again).
 
   ncpluginbuild (--help|-h)  : Print these usage instructions

--- a/testcode/utils/installncrystal.x
+++ b/testcode/utils/installncrystal.x
@@ -95,4 +95,4 @@ echo
 echo "If you wish to save space, you can remove the build leftovers with:"
 echo "   rm -rf ${ncbase}/bld"
 echo
-echo "This NCrystal installation will be automatically activated when you source testcode/util/bootstrap.sh"
+echo "This NCrystal installation will be automatically activated when you source testcode/utils/bootstrap.sh"


### PR DESCRIPTION
Update plugin for NCrystal v3.0.0. This essentially keeps the plugin as it was before, so it is not the final update. The final update needs to make a multiphase-aware plugin and use the new SANS utilities (as is done in the builtin hardspheres model).